### PR TITLE
feat: add typed model response parsing

### DIFF
--- a/backend/src/providers/replicate.test.ts
+++ b/backend/src/providers/replicate.test.ts
@@ -4,9 +4,16 @@ import assert from 'node:assert/strict';
 import { runSDXLControlNetDepth, replicate } from './replicate.ts';
 
 test('runSDXLControlNetDepth applies defaults when options undefined', async () => {
-  const runMock = mock.method(replicate as any, 'run', async (_model, opts) => {
-    return ['img'];
-  });
+  const runMock = mock.method(
+    replicate,
+    'run',
+    async (
+      _model: Parameters<typeof replicate.run>[0],
+      opts: Parameters<typeof replicate.run>[1]
+    ): Promise<object> => {
+      return ['img'] as unknown as object;
+    }
+  );
 
   const res = await runSDXLControlNetDepth({
     image: 'img',

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -18,11 +18,37 @@ const DEPTH_MODEL: ModelRef =
 const CONTROLNET_MODEL: ModelRef =
   (process.env.REPLICATE_CONTROLNET_DEPTH_MODEL ?? "lucataco/sdxl-controlnet-depth") as ModelRef;
 
-export async function runDepthAnythingV2(image: FileInput, modelSize: "Large" | "Base" = "Large"): Promise<string> {
-  const out = await replicate.run(DEPTH_MODEL, { input: { image, model: modelSize } }) as any;
+export interface DepthAnythingV2ResponseObject {
+  image?: string;
+  images?: string[];
+  depth_map?: string;
+  output?: string | string[];
+}
+
+export type DepthAnythingV2Response =
+  | string
+  | string[]
+  | DepthAnythingV2ResponseObject;
+
+export async function runDepthAnythingV2(
+  image: FileInput,
+  modelSize: "Large" | "Base" = "Large"
+): Promise<string> {
+  const out = (await replicate.run(DEPTH_MODEL, {
+    input: { image, model: modelSize }
+  })) as unknown as DepthAnythingV2Response;
+
   if (typeof out === "string") return out;
   if (Array.isArray(out) && out.length > 0) return out[0];
-  if (out?.image) return out.image;
+
+  if (typeof out === "object" && out !== null) {
+    if (typeof out.image === "string") return out.image;
+    if (Array.isArray(out.images) && out.images.length > 0) return out.images[0];
+    if (typeof out.depth_map === "string") return out.depth_map;
+    if (typeof out.output === "string") return out.output;
+    if (Array.isArray(out.output) && out.output.length > 0) return out.output[0];
+  }
+
   throw new Error("Unexpected depth model output shape");
 }
 
@@ -36,14 +62,35 @@ export interface ControlNetDepthInput {
   controlnet_conditioning_scale?: number;
 }
 
+export interface ControlNetDepthResponseObject {
+  images?: string[];
+  image?: string;
+  output?: string | string[];
+}
+
+export type ControlNetDepthResponse =
+  | string
+  | string[]
+  | ControlNetDepthResponseObject;
+
 export async function runSDXLControlNetDepth(input: ControlNetDepthInput): Promise<string[]> {
   const defaults = { num_inference_steps: 30, guidance_scale: 7, controlnet_conditioning_scale: 1.0 };
   const filtered = Object.fromEntries(
     Object.entries(input).filter(([, v]) => v !== undefined)
   );
-  const out = await replicate.run(CONTROLNET_MODEL, { input: { ...defaults, ...filtered } }) as any;
+  const out = (await replicate.run(CONTROLNET_MODEL, {
+    input: { ...defaults, ...filtered }
+  })) as unknown as ControlNetDepthResponse;
+
   if (Array.isArray(out)) return out.map(String);
   if (typeof out === "string") return [out];
-  if (out?.images && Array.isArray(out.images)) return out.images;
+
+  if (typeof out === "object" && out !== null) {
+    if (Array.isArray(out.images)) return out.images.map(String);
+    if (typeof out.image === "string") return [out.image];
+    if (Array.isArray(out.output)) return out.output.map(String);
+    if (typeof out.output === "string") return [out.output];
+  }
+
   throw new Error("Unexpected ControlNet output shape");
 }


### PR DESCRIPTION
## Summary
- add explicit interfaces for replicate model responses
- parse model outputs more defensively and remove `as any` casts
- update unit tests to mock replicate.run with proper typing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa0fd9e88083258a80f446fcc42105