### PR TITLE
Fix Docker build and TypeScript tests

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,7 @@ RUN if [ -f package-lock.json ]; then npm ci; else npm install; fi
 # ---- build ----
 FROM node:20-slim AS build
 WORKDIR /app
+COPY package.json package-lock.json* ./
 COPY --from=deps /app/node_modules ./node_modules
 COPY tsconfig.json ./
 COPY src ./src

--- a/backend/src/providers/replicate.test.ts
+++ b/backend/src/providers/replicate.test.ts
@@ -24,7 +24,7 @@ test('runSDXLControlNetDepth applies defaults when options undefined', async () 
 
   assert.deepEqual(res, ['img']);
   assert.equal(runMock.mock.calls.length, 1);
-  const input = runMock.mock.calls[0].arguments[1].input;
+  const input = (runMock.mock.calls[0].arguments[1] as any).input as any;
   assert.equal(input.guidance_scale, 7);
   assert.equal(input.num_inference_steps, 30);
   assert.equal(input.controlnet_conditioning_scale, 1.0);

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -47,7 +47,7 @@ export async function runDepthAnythingV2(
   if (typeof out === "string") return out;
   if (Array.isArray(out) && out.length > 0) return out[0];
 
-  if (typeof out === "object" && out !== null) {
+  if (!Array.isArray(out) && typeof out === "object" && out !== null) {
     if (typeof out.image === "string") return out.image;
     if (Array.isArray(out.images) && out.images.length > 0) return out.images[0];
     if (typeof out.depth_map === "string") return out.depth_map;


### PR DESCRIPTION
## Summary
- copy package manifest into Docker build stage so `npm run build` can run
- refine type narrowing in Replicate depth helper
- loosen test typings to satisfy the compiler

## Testing
- `REPLICATE_API_TOKEN=1 REPLICATE_DEPTH_MODEL=a/b REPLICATE_CONTROLNET_DEPTH_MODEL=c/d npm test`
- `npm run build`
- `docker build -t render-up-backend backend` *(fails: bash: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68aa126168848325975271b42926ea57