### PR TITLE
fix: improve upload dropzone behaviour

### DIFF
--- a/frontend/components/UploadDropzone.tsx
+++ b/frontend/components/UploadDropzone.tsx
@@ -10,18 +10,41 @@ export default function UploadDropzone({ onFileSelected }: Props) {
   const [isDragging, setDragging] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
 
-  const onDrop = useCallback((e: React.DragEvent) => {
+  const preventDefaults = useCallback((e: React.DragEvent) => {
     e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    preventDefaults(e);
     setDragging(false);
     const f = e.dataTransfer.files?.[0];
     if (f) onFileSelected(f);
+  }, [onFileSelected, preventDefaults]);
+
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    preventDefaults(e);
+    if (!isDragging) setDragging(true);
+  }, [preventDefaults, isDragging]);
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    preventDefaults(e);
+    setDragging(false);
+  }, [preventDefaults]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    if (f) onFileSelected(f);
+    // reset so selecting the same file again triggers onChange
+    e.target.value = "";
   }, [onFileSelected]);
 
   return (
     <div
-      onDragOver={(e) => { e.preventDefault(); setDragging(true); }}
-      onDragLeave={() => setDragging(false)}
-      onDrop={onDrop}
+      onDragOver={handleDragOver}
+      onDragEnter={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
       className={`border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition
         ${isDragging ? "border-blue-500 bg-blue-50" : "border-zinc-300 bg-white"}`}
       onClick={() => fileRef.current?.click()}
@@ -31,10 +54,8 @@ export default function UploadDropzone({ onFileSelected }: Props) {
         type="file"
         accept="image/*"
         className="hidden"
-        onChange={(e) => {
-          const f = e.target.files?.[0];
-          if (f) onFileSelected(f);
-        }}
+        onChange={handleChange}
+        onClick={(e) => e.stopPropagation()}
       />
       <p className="text-lg font-medium">Drop an image here, or click to select</p>
       <p className="text-sm text-zinc-500 mt-2">PNG or JPG, up to 20 MB</p>


### PR DESCRIPTION
## Summary
- improve drag and drop handling in UploadDropzone by preventing default browser behaviour
- reset file input on change and stop click propagation for reliable selection

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68aa20f2ea0c8325b3e60142e0d288cf