### PR TITLE
feat: add enhance pipeline

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -23,16 +23,22 @@ export default function Page() {
   const handleRun = async () => {
     if (!file) return;
     setLoading(true); setError(null); setResult(null);
-
-    const form = new FormData();
-    form.append("image", file);
-    form.append("preset", settings.preset);
-    form.append("strength", String(settings.strength));
-    form.append("preserveComposition", String(settings.preserveComposition));
-    form.append("upscale", settings.upscale);
+    const arrayBuffer = await file.arrayBuffer();
+    const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
+    const payload = {
+      image: `data:${file.type};base64,${base64}`,
+      preset: settings.preset,
+      strength: settings.strength,
+      preserveComposition: settings.preserveComposition,
+      upscale: settings.upscale,
+    };
 
     try {
-      const res = await fetch(`${API_BASE}/enhance`, { method: "POST", body: form });
+      const res = await fetch(`${API_BASE}/enhance`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
       if (!res.ok) throw new Error(`Server error ${res.status}`);
       const data = await res.json() as EnhanceResponse;
       setResult(data);


### PR DESCRIPTION
## Summary
- add `/enhance` endpoint to generate depth-guided photoreal images
- map lighting presets to prompts and return `EnhanceResponse`
- send base64 image payload from frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa24a76654832593cf03f46af01e86