### PR TITLE
Add multipart parser and enhance endpoint

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "render-up-backend",
       "version": "1.0.0",
       "dependencies": {
+        "busboy": "^1.6.0",
         "replicate": "^1.1.0"
       },
       "devDependencies": {
@@ -187,6 +188,17 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -314,6 +326,14 @@
       ],
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,8 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "replicate": "^1.1.0"
+    "replicate": "^1.1.0",
+    "busboy": "^1.6.0"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "busboy": "^1.6.0",
         "replicate": "^1.1.0"
       },
       "devDependencies": {
@@ -188,6 +189,17 @@
         "ieee754": "^1.2.1"
       }
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -315,6 +327,14 @@
       ],
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
-    "replicate": "^1.1.0"
+    "replicate": "^1.1.0",
+    "busboy": "^1.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- parse multipart/form-data uploads with Busboy
- add `/enhance` endpoint using depth and ControlNet models
- add busboy dependency

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa24ac8a088325b7ace4a99174e54a