### PR TITLE
Use FormData for enhance request

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -23,21 +23,18 @@ export default function Page() {
   const handleRun = async () => {
     if (!file) return;
     setLoading(true); setError(null); setResult(null);
-    const arrayBuffer = await file.arrayBuffer();
-    const base64 = btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
-    const payload = {
-      image: `data:${file.type};base64,${base64}`,
-      preset: settings.preset,
-      strength: settings.strength,
-      preserveComposition: settings.preserveComposition,
-      upscale: settings.upscale,
-    };
+
+    const form = new FormData();
+    form.append("image", file);
+    form.append("preset", settings.preset);
+    form.append("strength", settings.strength.toString());
+    form.append("preserveComposition", String(settings.preserveComposition));
+    form.append("upscale", settings.upscale);
 
     try {
       const res = await fetch(`${API_BASE}/enhance`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload)
+        body: form
       });
       if (!res.ok) throw new Error(`Server error ${res.status}`);
       const data = await res.json() as EnhanceResponse;


### PR DESCRIPTION
## Summary
- Switch frontend enhance request from JSON payload to multipart `FormData`
- Ensure backend continues to read `image` file and fields as strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2a47cd6883259ed500cc5fffa309