### PR TITLE
Add image preview to UploadDropzone

### DIFF
--- a/frontend/components/UploadDropzone.tsx
+++ b/frontend/components/UploadDropzone.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useCallback, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 interface Props {
   onFileSelected: (file: File) => void;
@@ -8,7 +8,14 @@ interface Props {
 
 export default function UploadDropzone({ onFileSelected }: Props) {
   const [isDragging, setDragging] = useState(false);
+  const [preview, setPreview] = useState<string | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    return () => {
+      if (preview) URL.revokeObjectURL(preview);
+    };
+  }, [preview]);
 
   const preventDefaults = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -19,7 +26,10 @@ export default function UploadDropzone({ onFileSelected }: Props) {
     preventDefaults(e);
     setDragging(false);
     const f = e.dataTransfer.files?.[0];
-    if (f) onFileSelected(f);
+    if (f) {
+      onFileSelected(f);
+      setPreview(URL.createObjectURL(f));
+    }
   }, [onFileSelected, preventDefaults]);
 
   const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
@@ -34,7 +44,10 @@ export default function UploadDropzone({ onFileSelected }: Props) {
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0];
-    if (f) onFileSelected(f);
+    if (f) {
+      onFileSelected(f);
+      setPreview(URL.createObjectURL(f));
+    }
     // reset so selecting the same file again triggers onChange
     e.target.value = "";
   }, [onFileSelected]);
@@ -59,6 +72,13 @@ export default function UploadDropzone({ onFileSelected }: Props) {
       />
       <p className="text-lg font-medium">Drop an image here, or click to select</p>
       <p className="text-sm text-zinc-500 mt-2">PNG or JPG, up to 20 MB</p>
+      {preview && (
+        <img
+          src={preview}
+          alt="preview"
+          className="mt-4 max-h-60 mx-auto"
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add preview state and image rendering to UploadDropzone
- revoke object URLs on cleanup to prevent memory leaks

## Testing
- `npm test`
- `npm --prefix frontend run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a54ed508325b6171569aea76b3d