### PR TITLE
feat: add CORS headers for backend

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -70,6 +70,16 @@ function parseJson(req: http.IncomingMessage): Promise<RequestBody> {
 }
 
 const server = http.createServer(async (req, res) => {
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "POST, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+  if (req.method === "OPTIONS") {
+    res.statusCode = 204;
+    res.end();
+    return;
+  }
+
   try {
     if (req.method === "POST" && req.url === "/depth") {
       const body = await parseJson(req);


### PR DESCRIPTION
## Summary
- set Access-Control headers for all backend responses
- handle OPTIONS preflight with 204 status for CORS

## Testing
- `npm test`
- `cd backend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aa32bd0bc883258ef4f3f9878841e6