### PR TITLE
Fix double slash in API base URL causing 404 on image requests

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -6,7 +6,7 @@ import Controls from "@/components/Controls";
 import CompareSlider from "@/components/CompareSlider";
 import type { EnhanceSettings, EnhanceResponse } from "@/lib/types";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8787";
+const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8787").replace(/\/$/, "");
 
 export default function Page() {
   const [file, setFile] = useState<File | null>(null);


### PR DESCRIPTION
## Summary
- strip trailing slash from API_BASE to avoid malformed URLs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4a41e44083258a26a95013d5a27a