### PR TITLE
Add environment examples and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Turn architectural renderings into photoreal images with improved lighting and m
 
 ## Environment variables
 
+Example settings are provided in `.env.example` files for both the backend and frontend.
+
 **Backend**
 
 - `REPLICATE_API_TOKEN` – required API token for Replicate

--- a/README.md
+++ b/README.md
@@ -5,9 +5,23 @@ Turn architectural renderings into photoreal images with improved lighting and m
 ## What is included
 
 - `frontend` Next.js app with a simple UI: upload, select lighting preset, strength, preserve toggle, size, compare slider.
-- `backend` Node/Express TypeScript server calling Replicate:
+- `backend` TypeScript HTTP server (no Express) calling Replicate:
   - Depth Anything V2 for depth
   - SDXL ControlNet Depth for faithful regeneration
+
+## Environment variables
+
+**Backend**
+
+- `REPLICATE_API_TOKEN` – required API token for Replicate
+- `REPLICATE_DEPTH_MODEL` – optional depth model override
+- `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override
+- `PORT` – optional port (defaults to `8787`)
+- `ALLOWED_ORIGIN` – optional CORS origin (defaults to `http://localhost:3000`)
+
+**Frontend**
+
+- `NEXT_PUBLIC_API_BASE_URL` – URL for the backend server
 
 ## Local run
 
@@ -17,7 +31,8 @@ Turn architectural renderings into photoreal images with improved lighting and m
    cp .env.example .env
    # configure PORT, ALLOWED_ORIGIN, REPLICATE_API_TOKEN and model IDs
    npm install
-   npm run dev
+   npm run build
+   npm start
    ```
 
 2. Frontend
@@ -33,7 +48,7 @@ Turn architectural renderings into photoreal images with improved lighting and m
 
 ## Deploy
 
-- Backend on Railway. Set env vars from `.env.example`.
+- Backend on Railway. Set the environment variables described above.
 - Frontend on Vercel. Set `NEXT_PUBLIC_API_BASE_URL` to the Railway service URL.
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Turn architectural renderings into photoreal images with improved lighting and m
    ```bash
    cd backend
    cp .env.example .env
-   # set REPLICATE_API_TOKEN
+   # configure PORT, ALLOWED_ORIGIN, REPLICATE_API_TOKEN and model IDs
    npm install
    npm run dev
    ```
@@ -24,6 +24,7 @@ Turn architectural renderings into photoreal images with improved lighting and m
    ```bash
    cd frontend
    cp .env.example .env.local
+   # set NEXT_PUBLIC_API_BASE_URL to your backend URL
    npm install
    npm run dev
    ```
@@ -37,5 +38,5 @@ Turn architectural renderings into photoreal images with improved lighting and m
 
 ## Notes
 
-- Model versions are pinned in `.env.example` for reproducibility.
+- Model versions are pinned in `backend/.env.example` for reproducibility.
 - Logs include a request id and timing for debugging.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,10 @@
+# Server configuration
+PORT=8787
+ALLOWED_ORIGIN=http://localhost:3000
+
+# Replicate API token
+REPLICATE_API_TOKEN=
+
+# Replicate model IDs (pin versions for reproducibility)
+REPLICATE_DEPTH_MODEL=nvidia/Depth-Anything-V2:MODEL_VERSION_ID
+REPLICATE_CONTROLNET_DEPTH_MODEL=stability-ai/sdxl-controlnet-depth:MODEL_VERSION_ID

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_BASE_URL=http://localhost:8787

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,7 +8,7 @@ Next.js app for the Architectural Photo Regenerator.
 cd frontend
 npm install
 cp .env.example .env.local
+# set NEXT_PUBLIC_API_BASE_URL to your backend URL
 npm run dev
 ```
-
-Open http://localhost:3000 and set NEXT_PUBLIC_API_BASE_URL to your backend URL.
+Then open http://localhost:3000.


### PR DESCRIPTION
## Summary
- add backend `.env.example` template covering port, CORS origin, Replicate token, and model IDs
- add frontend `.env.example` with `NEXT_PUBLIC_API_BASE_URL`
- document configuration steps for both apps

## Testing
- `npm run build` (backend) *(fails: Cannot find module 'image-size')*
- `npm run build` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_68aa5e908ed88325998a05fbaaac7a56