### PR TITLE
Adjust enhancement strength when preserving composition

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -108,9 +108,16 @@ const server = http.createServer(async (req, res) => {
       }
 
       const preset = fields.preset as LightingPreset;
-      const strength = fields.strength ? Number(fields.strength) : undefined;
+      let strength = fields.strength ? Number(fields.strength) : undefined;
       const preserveComposition = fields.preserveComposition === "true";
       const upscale = fields.upscale;
+
+      // When preserving composition, tone down the effect by reducing the
+      // provided strength value before passing it to the model. This helps
+      // maintain more of the original image structure.
+      if (preserveComposition && typeof strength === "number") {
+        strength *= 0.5;
+      }
 
       let width: number | undefined;
       let height: number | undefined;


### PR DESCRIPTION
## Summary
- Reduce enhancement strength by half when composition preservation is enabled
- Document strength reduction behavior for clarity

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa5e8f1330832592fe0f374034ce89