### PR TITLE
Ensure meta includes prompt strength preserveComposition

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -148,7 +148,11 @@ const server = http.createServer(async (req, res) => {
       const response = {
         requestId: randomUUID(),
         images,
-        meta: { preset, strength, preserveComposition, upscale, width, height },
+        preset,
+        upscale,
+        width,
+        height,
+        meta: { prompt, strength, preserveComposition },
         depthUrl,
       };
 


### PR DESCRIPTION
## Summary
- return only prompt, strength, and preserveComposition in the `meta` payload
- move preset, upscale, width, and height to top-level response fields

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'image-size' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5e8adb00832589957dbf6807444b