### PR TITLE
fix: use lowercase replicate depth model slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Turn architectural renderings into photoreal images with improved lighting and m
 **Backend**
 
 - `REPLICATE_API_TOKEN` – required API token for Replicate
-- `REPLICATE_DEPTH_MODEL` – optional depth model override
+- `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to
+  `nvidia/depth-anything-v2`)
 - `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override
 - `PORT` – optional port (defaults to `8787`)
 

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -29,7 +29,9 @@ export const replicate = new Replicate({
 // public model references so the app can run without custom configuration.
 const DEPTH_MODEL: ModelRef = getEnv(
   "REPLICATE_DEPTH_MODEL",
-  "nvidia/Depth-Anything-V2"
+  // Replicate model slugs are lowercase; use the proper casing to avoid 404s
+  // from the API when no override is supplied.
+  "nvidia/depth-anything-v2"
 ) as ModelRef;
 
 const CONTROLNET_MODEL: ModelRef = getEnv(


### PR DESCRIPTION
## Summary
- use lowercase model slug for default Depth Anything V2 to avoid 404s from Replicate
- document depth model default in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa6e0883a48325afc10d37a702cfa8