### PR TITLE
fix: normalize replicate model slugs and default CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Turn architectural renderings into photoreal images with improved lighting and m
 ## What is included
 
 - `frontend` Next.js app with a simple UI: upload, select lighting preset, strength, preserve toggle, size, compare slider.
-- `backend` TypeScript HTTP server (no Express) calling Replicate:
+- `backend` TypeScript Express server calling Replicate:
   - Depth Anything V2 for depth
   - SDXL ControlNet Depth for faithful regeneration
 
@@ -15,9 +15,12 @@ Turn architectural renderings into photoreal images with improved lighting and m
 **Backend**
 
 - `REPLICATE_API_TOKEN` – required API token for Replicate
-- `REPLICATE_DEPTH_MODEL` – optional depth model override
+- `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to
+  `nvidia/depth-anything-v2`); value is normalized to lowercase
 - `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override
+  (normalized to lowercase)
 - `PORT` – optional port (defaults to `8787`)
+- `ALLOWED_ORIGIN` – optional CORS origin; when unset all origins are allowed
 
 
 **Frontend**

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -31,8 +31,12 @@ app.use(
   })
 );
 
-// configure CORS via environment; defaults to undefined (no restriction)
-app.use(cors({ origin: process.env.ALLOWED_ORIGIN }));
+// configure CORS via environment; allow all origins when unset
+app.use(
+  process.env.ALLOWED_ORIGIN
+    ? cors({ origin: process.env.ALLOWED_ORIGIN })
+    : cors()
+);
 app.use(express.json());
 
 // In‑memory upload storage with a 20MB limit

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -27,15 +27,16 @@ export const replicate = new Replicate({
 
 // Cast env-provided model IDs to the stricter ModelRef type. Defaults are
 // public model references so the app can run without custom configuration.
+// Replicate model slugs are lowercase; normalize env override to prevent 404s
 const DEPTH_MODEL: ModelRef = getEnv(
   "REPLICATE_DEPTH_MODEL",
-  "nvidia/Depth-Anything-V2"
-) as ModelRef;
+  "nvidia/depth-anything-v2"
+).toLowerCase() as ModelRef;
 
 const CONTROLNET_MODEL: ModelRef = getEnv(
   "REPLICATE_CONTROLNET_DEPTH_MODEL",
   "stability-ai/sdxl-controlnet-depth"
-) as ModelRef;
+).toLowerCase() as ModelRef;
 
 // Normalize Replicate file outputs into plain URLs
 function toUrl(value: unknown): string | undefined {


### PR DESCRIPTION
## Summary
- normalize Replicate model slug environment overrides to lowercase
- allow all origins by default when ALLOWED_ORIGIN is unset
- document new CORS env var and slug normalization
- avoid TypeScript parsing error in default model constants

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6e0883a48325afc10d37a702cfa8