### PR TITLE
fix missing depth model default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Turn architectural renderings into photoreal images with improved lighting and m
 **Backend**
 
 - `REPLICATE_API_TOKEN` – required API token for Replicate
-- `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to
+- `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to `nateraw/depth-anything-v2`)
 
 - `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override
   (normalized to lowercase)

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -30,7 +30,9 @@ export const replicate = new Replicate({
 // Replicate model slugs are lowercase; normalize env override to prevent 404s
 const DEPTH_MODEL: ModelRef = getEnv(
   "REPLICATE_DEPTH_MODEL",
-
+  // Depth Anything V2 public model
+  "nateraw/depth-anything-v2"
+).toLowerCase() as ModelRef;
 
 const CONTROLNET_MODEL: ModelRef = getEnv(
   "REPLICATE_CONTROLNET_DEPTH_MODEL",


### PR DESCRIPTION
## Summary
- add default Depth Anything V2 model slug and normalize to lowercase
- document depth model default in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa7b4df7348325863d937a10621def