### PR TITLE
Update default Replicate depth model slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Turn architectural renderings into photoreal images with improved lighting and m
 **Backend**
 
 - `REPLICATE_API_TOKEN` – required API token for Replicate
-- `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to `nateraw/depth-anything-v2`)
+- `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to `chenxwh/depth-anything-v2`)
 
 - `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override
   (normalized to lowercase)

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -31,7 +31,7 @@ export const replicate = new Replicate({
 const DEPTH_MODEL: ModelRef = getEnv(
   "REPLICATE_DEPTH_MODEL",
   // Depth Anything V2 public model
-  "nateraw/depth-anything-v2"
+  "chenxwh/depth-anything-v2"
 ).toLowerCase() as ModelRef;
 
 const CONTROLNET_MODEL: ModelRef = getEnv(


### PR DESCRIPTION
## Summary
- use `chenxwh/depth-anything-v2` as the default Replicate depth model
- document new default `REPLICATE_DEPTH_MODEL` in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa85bec8fc8325ad8e9b8f12c289fb