### PR TITLE
chore: pin depth model version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Turn architectural renderings into photoreal images with improved lighting and m
 **Backend**
 
 - `REPLICATE_API_TOKEN` – required API token for Replicate
-- `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to `chenxwh/depth-anything-v2`)
+- `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to `chenxwh/depth-anything-v2:b239ea33cff32bb7abb5db39ffe9a09c14cbc2894331d1ef66fe096eed88ebd4`)
 
 - `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override
   (normalized to lowercase)

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -30,8 +30,8 @@ export const replicate = new Replicate({
 // Replicate model slugs are lowercase; normalize env override to prevent 404s
 const DEPTH_MODEL: ModelRef = getEnv(
   "REPLICATE_DEPTH_MODEL",
-  // Depth Anything V2 public model
-  "chenxwh/depth-anything-v2"
+  // Depth Anything V2 public model with pinned version
+  "chenxwh/depth-anything-v2:b239ea33cff32bb7abb5db39ffe9a09c14cbc2894331d1ef66fe096eed88ebd4"
 ).toLowerCase() as ModelRef;
 
 const CONTROLNET_MODEL: ModelRef = getEnv(


### PR DESCRIPTION
## Summary
- pin default depth model slug to `chenxwh/depth-anything-v2:b239ea33cff32bb7abb5db39ffe9a09c14cbc2894331d1ef66fe096eed88ebd4`
- document new default depth model slug in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa83a64a008325b77ba400108e039f