### PR TITLE
Handle direct FileOutput objects in depth model responses

### DIFF
--- a/backend/src/providers/replicate.test.ts
+++ b/backend/src/providers/replicate.test.ts
@@ -44,6 +44,19 @@ test('runDepthAnythingV2 returns URL string from FileOutput', async () => {
   runMock.mock.restore();
 });
 
+test('runDepthAnythingV2 handles direct FileOutput object', async () => {
+  const fake = { toString: () => 'https://example.com/out.png' } as any;
+  const runMock = mock.method(
+    replicate,
+    'run',
+    async (): Promise<any> => fake
+  );
+
+  const res = await runDepthAnythingV2('img');
+  assert.equal(res, 'https://example.com/out.png');
+  runMock.mock.restore();
+});
+
 test('runSDXLControlNetDepth handles FileOutput image property', async () => {
   const fake = { toString: () => 'https://example.com/out.png' } as any;
   const runMock = mock.method(

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -72,6 +72,19 @@ export async function runDepthAnythingV2(
     if (url) return url;
   }
 
+  if (
+    !Array.isArray(out) &&
+    typeof out === "object" &&
+    out !== null &&
+    typeof (out as any).toString === "function"
+  ) {
+    const url =
+      toUrl((out as any).url) ||
+      toUrl((out as any).data) ||
+      toUrl(out);
+    if (url) return url;
+  }
+
   if (!Array.isArray(out) && typeof out === "object" && out !== null) {
     const url =
       toUrl((out as any).image) ||


### PR DESCRIPTION
## Summary
- support FileOutput objects returned directly from Depth Anything V2
- test runDepthAnythingV2 with direct FileOutput object

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa8a484fdc8325b5d605b4012af417