### PR TITLE
chore: sanitize depth model error logging

### DIFF
--- a/backend/src/providers/replicate.test.ts
+++ b/backend/src/providers/replicate.test.ts
@@ -44,6 +44,28 @@ test('runDepthAnythingV2 returns URL string from FileOutput', async () => {
   runMock.mock.restore();
 });
 
+test('runDepthAnythingV2 error includes sanitized sample', async () => {
+  const runMock = mock.method(
+    replicate,
+    'run',
+    async (): Promise<any> => ({ foo: 'a'.repeat(500) })
+  );
+
+  try {
+    await assert.rejects(
+      () => runDepthAnythingV2('img'),
+      (err: any) => {
+        assert.match(err.message, /Unexpected depth model output shape/);
+        assert.match(err.message, /foo/);
+        assert.ok(err.message.length < 260);
+        return true;
+      }
+    );
+  } finally {
+    runMock.mock.restore();
+  }
+});
+
 test('runSDXLControlNetDepth handles FileOutput image property', async () => {
   const fake = { toString: () => 'https://example.com/out.png' } as any;
   const runMock = mock.method(

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -46,6 +46,19 @@ function toUrl(value: unknown): string | undefined {
   return undefined;
 }
 
+function sampleForLogging(value: unknown, maxLength = 200): string {
+  try {
+    const json = JSON.stringify(
+      value,
+      (_key, v) =>
+        typeof v === "string" && v.length > 100 ? `${v.slice(0, 97)}...` : v
+    );
+    return json.slice(0, maxLength);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
 export interface DepthAnythingV2ResponseObject {
   image?: string;
   images?: string[];
@@ -82,7 +95,9 @@ export async function runDepthAnythingV2(
     if (url) return url;
   }
 
-  throw new Error("Unexpected depth model output shape");
+  throw new Error(
+    `Unexpected depth model output shape: ${sampleForLogging(out)}`
+  );
 }
 
 export interface ControlNetDepthInput {
@@ -127,5 +142,7 @@ export async function runSDXLControlNetDepth(input: ControlNetDepthInput): Promi
     if (typeof (out as any).output === "string") return [(out as any).output];
   }
 
-  throw new Error("Unexpected ControlNet output shape");
+  throw new Error(
+    `Unexpected ControlNet output shape: ${sampleForLogging(out)}`
+  );
 }


### PR DESCRIPTION
## Summary
- add `sampleForLogging` to truncate and sanitize model outputs before logging
- include sanitized output samples in depth model and ControlNet error messages
- test depth model error formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa8a55925483259a383d1299e882bd