### PR TITLE
feat: log depth model output before error

### DIFF
--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -1,7 +1,10 @@
 import Replicate from "replicate";
 import type { Readable } from "node:stream";
+import pino from "pino";
 
 export type FileInput = Buffer | Readable | string;
+
+const logger = pino();
 
 // --- Add a template literal type for Replicate model references ---
 type ModelRef = `${string}/${string}` | `${string}/${string}:${string}`;
@@ -82,6 +85,13 @@ export async function runDepthAnythingV2(
     if (url) return url;
   }
 
+  logger.error(
+    {
+      outType: typeof out,
+      outKeys: typeof out === "object" && out !== null ? Object.keys(out as any) : undefined,
+    },
+    "Unexpected depth model output shape",
+  );
   throw new Error("Unexpected depth model output shape");
 }
 


### PR DESCRIPTION
## Summary
- add pino logger and record depth model `out` details before error

## Testing
- `npm test`
- `npm run build`
- `railway up --environment staging` *(fails: CLI deprecated)*
- `npm install -g @railway/cli --force` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68aa8a58bdc083258b758665d3beda76