### PR TITLE
fix: update ControlNet model default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Turn architectural renderings into photoreal images with improved lighting and m
 - `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to `chenxwh/depth-anything-v2:b239ea33cff32bb7abb5db39ffe9a09c14cbc2894331d1ef66fe096eed88ebd4`)
 
 - `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override
-  (normalized to lowercase)
+  (defaults to `jagilley/controlnet-depth-sdxl`, normalized to lowercase)
 - `PORT` – optional port (defaults to `8787`)
 - `ALLOWED_ORIGIN` – optional CORS origin; when unset all origins are allowed
 

--- a/backend/src/providers/replicate.test.ts
+++ b/backend/src/providers/replicate.test.ts
@@ -39,13 +39,10 @@ test('runDepthAnythingV2 returns URL string from FileOutput', async () => {
     async (): Promise<any> => [fake]
   );
 
-  const res = await runDepthAnythingV2('img');
-  assert.equal(res, 'https://example.com/out.png');
-  runMock.mock.restore();
-});
-
-
-});
+    const res = await runDepthAnythingV2('img');
+    assert.equal(res, 'https://example.com/out.png');
+    runMock.mock.restore();
+  });
 
 test('runSDXLControlNetDepth handles FileOutput image property', async () => {
   const fake = { toString: () => 'https://example.com/out.png' } as any;

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -39,7 +39,7 @@ const DEPTH_MODEL: ModelRef = getEnv(
 
 const CONTROLNET_MODEL: ModelRef = getEnv(
   "REPLICATE_CONTROLNET_DEPTH_MODEL",
-  "stability-ai/sdxl-controlnet-depth"
+  "jagilley/controlnet-depth-sdxl"
 ).toLowerCase() as ModelRef;
 
 // Normalize Replicate file outputs into plain URLs


### PR DESCRIPTION
## Summary
- fix Replicate 404 by updating default ControlNet model slug to `jagilley/controlnet-depth-sdxl`
- document ControlNet default model in README
- clean up Replicate provider tests for TypeScript

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa8bcb841c8325a05e1c5750fe69ce