### PR TITLE
Handle missing Replicate model versions to prevent 404s

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ Turn architectural renderings into photoreal images with improved lighting and m
 **Backend**
 
 - `REPLICATE_API_TOKEN` – required API token for Replicate
-- `REPLICATE_DEPTH_MODEL` – optional depth model override (defaults to `chenxwh/depth-anything-v2:b239ea33cff32bb7abb5db39ffe9a09c14cbc2894331d1ef66fe096eed88ebd4`)
+- `REPLICATE_DEPTH_MODEL` – optional depth model override. If the value omits a
+  version, the backend resolves the latest model version automatically. The
+  default is `chenxwh/depth-anything-v2:b239ea33cff32bb7abb5db39ffe9a09c14cbc2894331d1ef66fe096eed88ebd4`.
 
-- `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override
-  (defaults to `jagilley/controlnet-depth-sdxl`, normalized to lowercase)
+- `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override. When
+  no version is provided the backend fetches the latest version to avoid API
+  404 errors. Defaults to `jagilley/controlnet-depth-sdxl`.
 - `PORT` – optional port (defaults to `8787`)
 - `ALLOWED_ORIGIN` – optional CORS origin; when unset all origins are allowed
 

--- a/backend/src/providers/replicate.test.ts
+++ b/backend/src/providers/replicate.test.ts
@@ -4,6 +4,11 @@ import assert from 'node:assert/strict';
 import { runSDXLControlNetDepth, runDepthAnythingV2, replicate } from './replicate';
 
 test('runSDXLControlNetDepth applies defaults when options undefined', async () => {
+  const getMock = mock.method(
+    replicate.models,
+    'get',
+    async () => ({ latest_version: { id: 'v1' } }) as any
+  );
   const runMock = mock.method(
     replicate,
     'run',
@@ -29,6 +34,7 @@ test('runSDXLControlNetDepth applies defaults when options undefined', async () 
   assert.equal(input.num_inference_steps, 30);
   assert.equal(input.controlnet_conditioning_scale, 1.0);
   runMock.mock.restore();
+  getMock.mock.restore();
 });
 
 test('runDepthAnythingV2 returns URL string from FileOutput', async () => {
@@ -46,6 +52,11 @@ test('runDepthAnythingV2 returns URL string from FileOutput', async () => {
 
 test('runSDXLControlNetDepth handles FileOutput image property', async () => {
   const fake = { toString: () => 'https://example.com/out.png' } as any;
+  const getMock = mock.method(
+    replicate.models,
+    'get',
+    async () => ({ latest_version: { id: 'v1' } }) as any
+  );
   const runMock = mock.method(
     replicate,
     'run',
@@ -60,9 +71,15 @@ test('runSDXLControlNetDepth handles FileOutput image property', async () => {
 
   assert.deepEqual(res, ['https://example.com/out.png']);
   runMock.mock.restore();
+  getMock.mock.restore();
 });
 
 test('runSDXLControlNetDepth forwards width and height', async () => {
+  const getMock = mock.method(
+    replicate.models,
+    'get',
+    async () => ({ latest_version: { id: 'v1' } }) as any
+  );
   const runMock = mock.method(
     replicate,
     'run',
@@ -81,5 +98,6 @@ test('runSDXLControlNetDepth forwards width and height', async () => {
   assert.equal(input.width, 512);
   assert.equal(input.height, 768);
   runMock.mock.restore();
+  getMock.mock.restore();
 });
 


### PR DESCRIPTION
## Summary
- resolve missing version identifiers before calling Replicate API
- document automatic version resolution in README
- update tests to mock Replicate model lookup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa8d87ff208325ad8cffa3a073976a