### PR TITLE
Pin Replicate ControlNet model version

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ Turn architectural renderings into photoreal images with improved lighting and m
   version, the backend resolves the latest model version automatically. The
   default is `chenxwh/depth-anything-v2:b239ea33cff32bb7abb5db39ffe9a09c14cbc2894331d1ef66fe096eed88ebd4`.
 
-- `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override. When
-  no version is provided the backend fetches the latest version to avoid API
-  404 errors. Defaults to `jagilley/controlnet-depth-sdxl`.
+- `REPLICATE_CONTROLNET_DEPTH_MODEL` – optional ControlNet model override. A
+  fully qualified `owner/model:version` reference avoids Replicate API 404s.
+  Defaults to
+  `jagilley/controlnet-depth-sdxl:9ca98281fa9ba02b96c8a17cc4430ebdc80bd048393ca5c7d07212e08a3b3fc3`.
 - `PORT` – optional port (defaults to `8787`)
 - `ALLOWED_ORIGIN` – optional CORS origin; when unset all origins are allowed
 

--- a/backend/src/providers/replicate.ts
+++ b/backend/src/providers/replicate.ts
@@ -39,7 +39,10 @@ const DEPTH_MODEL: ModelRef = getEnv(
 
 const CONTROLNET_MODEL: ModelRef = getEnv(
   "REPLICATE_CONTROLNET_DEPTH_MODEL",
-  "jagilley/controlnet-depth-sdxl"
+  // Pinned model version so Replicate's API doesn't require a version lookup
+  // which can return 404s when the model-specific predictions endpoint is
+  // unavailable.
+  "jagilley/controlnet-depth-sdxl:9ca98281fa9ba02b96c8a17cc4430ebdc80bd048393ca5c7d07212e08a3b3fc3"
 ).toLowerCase() as ModelRef;
 
 /**


### PR DESCRIPTION
## Summary
- pin `jagilley/controlnet-depth-sdxl` to a specific version to avoid 404s from Replicate's model-specific endpoint
- document default ControlNet model reference with version

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa8f3f2af48325b7384142d832624f