### PR TITLE
Fix frontend enhance route to use new API

### DIFF
--- a/frontend/components/Controls.tsx
+++ b/frontend/components/Controls.tsx
@@ -65,12 +65,13 @@ export default function Controls({ settings, onChange, disabled }: Props) {
           className="w-full border rounded-lg px-3 py-2"
           value={settings.upscale}
           onChange={e =>
-            onChange({ ...settings, upscale: e.target.value as "native" | "1.5x" })
+            onChange({ ...settings, upscale: e.target.value as "none" | "2x" | "4x" })
           }
           disabled={disabled}
         >
-          <option value="native">Native</option>
-          <option value="1.5x">1.5x</option>
+          <option value="none">Original</option>
+          <option value="2x">2x</option>
+          <option value="4x">4x</option>
         </select>
       </div>
     </div>

--- a/frontend/lib/enhanceClient.ts
+++ b/frontend/lib/enhanceClient.ts
@@ -1,3 +1,5 @@
+import type { EnhanceResponse } from "./types";
+
 export async function enhanceImage({
   file,
   imageUrl,
@@ -9,12 +11,12 @@ export async function enhanceImage({
 }: {
   file?: File;
   imageUrl?: string;
-  preset?: "neutral_overcast"|"golden_hour"|"dramatic";
+  preset?: "neutral_overcast"|"golden_hour"|"dramatic"|"dramatic_contrast";
   strength?: number;
   preserve_composition?: boolean;
   upscale?: "none"|"2x"|"4x";
   mode?: "sync"|"async";
-}) {
+}): Promise<EnhanceResponse> {
   const form = new FormData();
   if (file) form.append("file", file);
   if (imageUrl) form.append("imageUrl", imageUrl);

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -4,12 +4,17 @@ export interface EnhanceSettings {
   preset: LightingPreset;
   strength: number; // 0 to 1
   preserveComposition: boolean;
-  upscale: "native" | "1.5x";
+  upscale: "none" | "2x" | "4x";
 }
 
 export interface EnhanceResponse {
-  requestId: string;
-  images: string[]; // URLs to images
-  meta: Record<string, any>;
-  depthUrl?: string;
+  status: string;
+  input: {
+    preset: LightingPreset;
+    preserve_composition?: boolean;
+    upscale: "none" | "2x" | "4x";
+  };
+  output: {
+    image: string;
+  };
 }


### PR DESCRIPTION
## Summary
- switch UI to use `/api/enhance`
- support 2x and 4x upscale options
- adapt to new response format from backend

## Testing
- `npm test`
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab40e68700832584291a480435e958